### PR TITLE
Support subgraph short hand syntax

### DIFF
--- a/src/print/original.ts
+++ b/src/print/original.ts
@@ -1,14 +1,14 @@
 import { AST } from '@ts-graphviz/parser';
 import { doc, Doc } from 'prettier';
 import { PrintOption } from './types';
+import { getOriginal } from './utils';
 
 const {
   builders: { literalline },
 } = doc;
 
-export function printOriginal({ node, options }: PrintOption<AST.ASTNode>): Doc {
-  return options.originalText
-    .slice(options.locStart(node), options.locEnd(node))
+export function printOriginal(option: PrintOption<AST.ASTNode>): Doc {
+  return getOriginal(option)
     .split('\n')
     .flatMap((o, i) => (i == 0 ? o : [literalline, o]));
 }

--- a/src/print/subgraph.ts
+++ b/src/print/subgraph.ts
@@ -1,18 +1,25 @@
 import { AST } from '@ts-graphviz/parser';
 import { doc, Doc } from 'prettier';
 import { PrintOption } from './types';
+import { getOriginal } from './utils';
 
 const {
-  builders: { group, ifBreak, softline, indent },
+  builders: { group, ifBreak, softline, indent, join },
 } = doc;
 
-export function printSubgraph({ node, path, print }: PrintOption<AST.Subgraph>): Doc {
-  return node.body.length === 0
-    ? [node.id ? group(['subgraph ', path.call(print, 'id'), ifBreak(softline, ' '), '{}']) : 'subgraph {}']
-    : [
-        node.id ? group(['subgraph ', path.call(print, 'id'), ifBreak(softline, ' '), '{']) : 'subgraph {',
-        indent([path.map((p) => [softline, print(p)], 'body')]),
-        softline,
-        '}',
-      ];
+const keyword = 'subgraph';
+
+export function printSubgraph(option: PrintOption<AST.Subgraph>): Doc {
+  const { node, path, print } = option;
+  return getOriginal(option).slice(0, keyword.length).toLowerCase() === keyword
+    ? node.body.length === 0
+      ? [node.id ? group(['subgraph ', path.call(print, 'id'), ifBreak(softline, ' '), '{}']) : 'subgraph {}']
+      : [
+          node.id ? group(['subgraph ', path.call(print, 'id'), ifBreak(softline, ' '), '{']) : 'subgraph {',
+          indent([path.map((p) => [softline, print(p)], 'body')]),
+          softline,
+          '}',
+        ]
+    : // Short Hand
+      ['{ ', join(' ', path.map(print, 'body')), ' }'];
 }

--- a/src/print/utils.ts
+++ b/src/print/utils.ts
@@ -25,3 +25,7 @@ export function printBody({ path, print, options }: PrintOption<AST.ASTNode>): D
 
   return join(hardline, parts);
 }
+
+export function getOriginal({ node, options }: PrintOption<AST.ASTNode>): string {
+  return options.originalText.slice(options.locStart(node), options.locEnd(node));
+}

--- a/test/subgraph.test.ts
+++ b/test/subgraph.test.ts
@@ -52,3 +52,17 @@ test('subgraph in contents', () => {
     }
   `);
 });
+
+test('short hand subgraph', () => {
+  expect(
+    format(`
+    digraph {
+      { rank=same; A; B C D }
+    }
+    `),
+  ).toMatchInlineSnapshot(`
+    digraph {
+      { rank=same; A; B; C; D; }
+    }
+  `);
+});


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

When formatting the Subgraph shorthand notation, the subgraph keyword is added and the shorthand notation is canceled.

### How this PR fixes the problem

Fixed to be formatted while keeping the short hand notation.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
